### PR TITLE
OCI Artifact manifest specifiaction

### DIFF
--- a/src/image/artifact.rs
+++ b/src/image/artifact.rs
@@ -1,0 +1,215 @@
+use super::{Descriptor, MediaType};
+use crate::error::{OciSpecError, Result};
+use derive_builder::Builder;
+use getset::{Getters, MutGetters, Setters};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+    path::Path,
+};
+
+#[derive(
+    Builder, Clone, Debug, Deserialize, Eq, Getters, MutGetters, Setters, PartialEq, Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[builder(
+    pattern = "owned",
+    setter(into, strip_option),
+    build_fn(error = "OciSpecError")
+)]
+/// The OCI Artifact manifest describes content addressable artifacts
+/// in order to store them along side container images in a registry.
+pub struct ArtifactManifest {
+    /// This property MUST be used and contain the media type
+    /// `application/vnd.oci.artifact.manifest.v1+json`.
+    #[getset(get = "pub")]
+    #[builder(default = "MediaType::ArtifactManifest")]
+    #[builder(setter(skip))]
+    media_type: MediaType,
+
+    /// This property SHOULD be used and contain
+    /// the mediaType of the referenced artifact.
+    /// If defined, the value MUST comply with RFC 6838,
+    /// including the naming requirements in its section 4.2,
+    /// and MAY be registered with IANA.
+    #[getset(get = "pub", set = "pub")]
+    artifact_type: MediaType,
+
+    /// This OPTIONAL property is an array of objects and each item
+    /// in the array MUST be a descriptor. Each descriptor represents
+    /// an artifact of any IANA mediaType. The list MAY be ordered
+    /// for certain artifact types like scan results.
+    #[getset(get_mut = "pub", get = "pub", set = "pub")]
+    #[builder(default)]
+    blobs: Vec<Descriptor>,
+
+    /// This OPTIONAL property specifies a descriptor of another manifest.
+    /// This value, used by the referrers API, indicates a relationship
+    /// to the specified manifest.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub", set = "pub")]
+    #[builder(default)]
+    subject: Option<Descriptor>,
+
+    /// This OPTIONAL property contains additional metadata for the artifact
+    /// manifest. This OPTIONAL property MUST use the annotation rules.
+    /// See Pre-Defined Annotation Keys. Annotations MAY be used to filter
+    /// the response from the referrers API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get_mut = "pub", get = "pub", set = "pub")]
+    #[builder(default)]
+    annotations: Option<HashMap<String, String>>,
+}
+
+impl ArtifactManifest {
+    /// Attempts to load an image manifest from a file.
+    ///
+    /// # Errors
+    ///
+    /// - [OciSpecError::Io] if the file does not exist
+    /// - [OciSpecError::SerDe] if the image manifest cannot be deserialized.
+    ///
+    /// # Example
+    ///
+    /// ``` no_run
+    /// use oci_spec::image::ArtifactManifest;
+    ///
+    /// let artifact_manifest = ArtifactManifest::from_file("manifest.json").unwrap();
+    /// ```
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
+        crate::from_file(path)
+    }
+
+    /// Attempts to load an image manifest from a stream.
+    ///
+    /// # Errors
+    ///
+    /// - [OciSpecError::SerDe](crate::OciSpecError::SerDe) if the manifest cannot be deserialized.
+    ///
+    /// # Example
+    ///
+    /// ``` no_run
+    /// use oci_spec::image::ArtifactManifest;
+    /// use std::fs::File;
+    ///
+    /// let reader = File::open("manifest.json").unwrap();
+    /// let artifact_manifest = ArtifactManifest::from_reader(reader).unwrap();
+    /// ```
+    pub fn from_reader<R: Read>(reader: R) -> Result<Self> {
+        crate::from_reader(reader)
+    }
+
+    /// Attempts to write an image manifest to a file as JSON. If the file already exists, it
+    /// will be overwritten.
+    ///
+    /// # Errors
+    ///
+    /// - [OciSpecError::SerDe](crate::OciSpecError::SerDe) if the image manifest cannot be serialized.
+    ///
+    /// # Example
+    ///
+    /// ``` no_run
+    /// use oci_spec::image::ArtifactManifest;
+    ///
+    /// let artifact_manifest = ArtifactManifest::from_file("manifest.json").unwrap();
+    /// artifact_manifest.to_file("my-manifest.json").unwrap();
+    /// ```
+    pub fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        crate::to_file(&self, path, false)
+    }
+
+    /// Attempts to write an image manifest to a file as pretty printed JSON. If the file already exists, it
+    /// will be overwritten.
+    ///
+    /// # Errors
+    ///
+    /// - [OciSpecError::SerDe](crate::OciSpecError::SerDe) if the image manifest cannot be serialized.
+    ///
+    /// # Example
+    ///
+    /// ``` no_run
+    /// use oci_spec::image::ArtifactManifest;
+    ///
+    /// let artifact_manifest = ArtifactManifest::from_file("manifest.json").unwrap();
+    /// artifact_manifest.to_file_pretty("my-manifest.json").unwrap();
+    /// ```
+    pub fn to_file_pretty<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        crate::to_file(&self, path, true)
+    }
+
+    /// Attempts to write an image manifest to a stream as JSON.
+    ///
+    /// # Errors
+    ///
+    /// - [OciSpecError::SerDe](crate::OciSpecError::SerDe) if the image manifest cannot be serialized.
+    ///
+    /// # Example
+    ///
+    /// ``` no_run
+    /// use oci_spec::image::ArtifactManifest;
+    ///
+    /// let artifact_manifest = ArtifactManifest::from_file("manifest.json").unwrap();
+    /// let mut writer = Vec::new();
+    /// artifact_manifest.to_writer(&mut writer);
+    /// ```
+    pub fn to_writer<W: Write>(&self, writer: &mut W) -> Result<()> {
+        crate::to_writer(&self, writer, false)
+    }
+
+    /// Attempts to write an image manifest to a stream as pretty printed JSON.
+    ///
+    /// # Errors
+    ///
+    /// - [OciSpecError::SerDe](crate::OciSpecError::SerDe) if the image manifest cannot be serialized.
+    ///
+    /// # Example
+    ///
+    /// ``` no_run
+    /// use oci_spec::image::ArtifactManifest;
+    ///
+    /// let artifact_manifest = ArtifactManifest::from_file("manifest.json").unwrap();
+    /// let mut writer = Vec::new();
+    /// artifact_manifest.to_writer_pretty(&mut writer);
+    /// ```
+    pub fn to_writer_pretty<W: Write>(&self, writer: &mut W) -> Result<()> {
+        crate::to_writer(&self, writer, true)
+    }
+
+    /// Attempts to write an image manifest to a string as JSON.
+    ///
+    /// # Errors
+    ///
+    /// - [OciSpecError::SerDe](crate::OciSpecError::SerDe) if the image configuration cannot be serialized.
+    ///
+    /// # Example
+    ///
+    /// ``` no_run
+    /// use oci_spec::image::ArtifactManifest;
+    ///
+    /// let artifact_manifest = ArtifactManifest::from_file("manifest.json").unwrap();
+    /// let json_str = artifact_manifest.to_string().unwrap();
+    /// ```
+    pub fn to_string(&self) -> Result<String> {
+        crate::to_string(&self, false)
+    }
+
+    /// Attempts to write an image manifest to a string as pretty printed JSON.
+    ///
+    /// # Errors
+    ///
+    /// - [OciSpecError::SerDe](crate::OciSpecError::SerDe) if the image configuration cannot be serialized.
+    ///
+    /// # Example
+    ///
+    /// ``` no_run
+    /// use oci_spec::image::ArtifactManifest;
+    ///
+    /// let artifact_manifest = ArtifactManifest::from_file("manifest.json").unwrap();
+    /// let json_str = artifact_manifest.to_string_pretty().unwrap();
+    /// ```
+    pub fn to_string_pretty(&self) -> Result<String> {
+        crate::to_string(&self, true)
+    }
+}
+

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -53,6 +53,9 @@ pub enum MediaType {
     /// MediaType ImageConfig specifies the media type for the image
     /// configuration.
     ImageConfig,
+    /// MediaType ArtifactManifest specifies the media type used for content addressable
+    /// artifacts to store them along side container images in a registry.
+    ArtifactManifest,
     /// MediaType not specified by OCI image format.
     Other(String),
 }
@@ -79,6 +82,7 @@ impl Display for MediaType {
                 "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd"
             ),
             Self::ImageConfig => write!(f, "application/vnd.oci.image.config.v1+json"),
+            Self::ArtifactManifest => write!(f, "application/vnd.oci.artifact.manifest.v1+json"),
             Self::Other(media_type) => write!(f, "{}", media_type),
         }
     }
@@ -104,6 +108,7 @@ impl From<&str> for MediaType {
                 MediaType::ImageLayerNonDistributableZstd
             }
             "application/vnd.oci.image.config.v1+json" => MediaType::ImageConfig,
+            "application/vnd.oci.artifact.manifest.v1+json" => MediaType::ArtifactManifest,
             media => MediaType::Other(media.to_owned()),
         }
     }

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,6 +1,7 @@
 //! [OCI image spec](https://github.com/opencontainers/image-spec) types and definitions.
 
 mod annotations;
+mod artifact;
 mod config;
 mod descriptor;
 mod index;
@@ -12,6 +13,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 
 pub use annotations::*;
+pub use artifact::*;
 pub use config::*;
 pub use descriptor::*;
 pub use index::*;

--- a/test/data/artifact_manifest.json
+++ b/test/data/artifact_manifest.json
@@ -1,0 +1,20 @@
+{
+  "mediaType": "application/vnd.oci.artifact.manifest.v1+json",
+  "artifactType": "application/vnd.example.sbom.v1",
+  "blobs": [
+    {
+      "mediaType": "application/gzip",
+      "size": 123,
+      "digest": "sha256:87923725d74f4bfb94c9e86d64170f7521aad8221a5de834851470ca142da630"
+    }
+  ],
+  "subject": {
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "size": 1234,
+    "digest": "sha256:cc06a2839488b8bd2a2b99dcdc03d5cfd818eed72ad08ef3cc197aac64c0d0a0"
+  },
+  "annotations": {
+    "org.opencontainers.artifact.created": "2022-01-01T14:42:55Z",
+    "org.example.sbom.format": "json"
+  }
+}


### PR DESCRIPTION
Working PR, aiming to send actual PR.

Add support for [OCI Artifact manifest specifiaction](https://github.com/opencontainers/image-spec/blob/main/artifact.md), which will be introduced in OCI image spec v1.1.0 (currently [rc2](https://github.com/opencontainers/image-spec/releases/tag/v1.1.0-rc2)) 